### PR TITLE
Allow for getting simulators that are not loaded yet

### DIFF
--- a/kaleidoscope/__init__.py
+++ b/kaleidoscope/__init__.py
@@ -26,4 +26,4 @@ from kaleidoscope.backends.mpl import *
 
 from kaleidoscope.backends.simulators import KaleidoscopeSimulatorService
 
-Simulators = KaleidoscopeSimulatorService()
+simulators = KaleidoscopeSimulatorService()

--- a/kaleidoscope/backends/simulators.py
+++ b/kaleidoscope/backends/simulators.py
@@ -127,11 +127,11 @@ class KaleidoscopeSimulatorService():
     or :code:`ibmq_*`.
 
     Systems are attached to the service as attributes and the service
-    object is available at the top-level via :code:`Simulators`.
+    object is available at the top-level via :code:`simulators`.
     For example, a :code:`ibmq_vigo` simulator using :code:`Aer` can be retrieved
     via:
 
-    .. code-block:: python
+    .. jupyter-execute::
 
         import kaleidoscope as kal
         sim = kal.simulators.aer_vigo_simulator

--- a/kaleidoscope/backends/simulators.py
+++ b/kaleidoscope/backends/simulators.py
@@ -134,7 +134,7 @@ class KaleidoscopeSimulatorService():
     .. code-block:: python
 
         import kaleidoscope as kal
-        sim = kal.Simulators.aer_vigo_simulator
+        sim = kal.simulators.aer_vigo_simulator
 
     Attributes:
         refreshing (bool): Is the service refreshing its simulators async.

--- a/kaleidoscope/backends/simulators.py
+++ b/kaleidoscope/backends/simulators.py
@@ -153,7 +153,7 @@ class KaleidoscopeSimulatorService():
             if attr in self.__dict__:
                 return self.__dict__[attr]
         if attr not in self.__dict__:
-            raise AttributeError("Couldn't load {} simulator.".format(attr))
+            raise AttributeError("Couldn't load {}.".format(attr))
         return self.__dict__[attr]
 
     def refresh(self):

--- a/kaleidoscope/backends/simulators.py
+++ b/kaleidoscope/backends/simulators.py
@@ -148,13 +148,16 @@ class KaleidoscopeSimulatorService():
         return list(vars(self).keys())
 
     def __getattr__(self, attr):
-        while self.refreshing:
-            time.sleep(0.1)
-            if attr in self.__dict__:
-                return self.__dict__[attr]
-        if attr not in self.__dict__:
-            raise AttributeError("Couldn't load {}.".format(attr))
-        return self.__dict__[attr]
+        if 'aer' in attr or 'ibmq' in attr:
+            while self.refreshing:
+                time.sleep(0.1)
+                if attr in self.__dict__:
+                    return self.__dict__[attr]
+            if attr not in self.__dict__:
+                raise AttributeError("Couldn't load {}.".format(attr))
+            return self.__dict__[attr]
+        else:
+            raise AttributeError("Simulators does not have attribute {}".format(attr))
 
     def refresh(self):
         """Refresh the service for new backends if IBMQ

--- a/kaleidoscope/backends/simulators.py
+++ b/kaleidoscope/backends/simulators.py
@@ -14,6 +14,7 @@
 
 """Module for creating device simulators automatically"""
 
+import time
 import threading
 from qiskit import IBMQ, Aer
 from qiskit.providers import BaseBackend
@@ -145,6 +146,15 @@ class KaleidoscopeSimulatorService():
 
     def __call__(self):
         return list(vars(self).keys())
+
+    def __getattr__(self, attr):
+        while self.refreshing:
+            time.sleep(0.1)
+            if attr in self.__dict__:
+                return self.__dict__[attr]
+        if attr not in self.__dict__:
+            raise AttributeError("Couldn't load {} simulator.".format(attr))
+        return self.__dict__[attr]
 
     def refresh(self):
         """Refresh the service for new backends if IBMQ


### PR DESCRIPTION
This makes the simulator service `__getattr__` block until the particular simulator called on is loaded.

This breaks autocomplete due to what appears to be a bug in Jupyters autocomplete: https://github.com/jupyter/notebook/issues/5517 