### PR TITLE
Change cnot err colors

### DIFF
--- a/kaleidoscope/colors/__init__.py
+++ b/kaleidoscope/colors/__init__.py
@@ -18,3 +18,7 @@ from kaleidoscope.colors.cmap import cmap_to_plotly
 
 # The Blue->Magenta->Yellow sequential color map from ColorCet for plotly
 BMY_PLOTLY = cmap_to_plotly(cc.cm.bmy)
+
+# Dark2 from colorbrewer
+DARK2 = ["#1b9e77", "#d95f02", "#7570b3", "#e7298a",
+         "#66a61e", "#e6ab02", "#a6761d", "#666666"]

--- a/kaleidoscope/interactive/bloch/bloch3d.py
+++ b/kaleidoscope/interactive/bloch/bloch3d.py
@@ -16,14 +16,11 @@
 
 import numpy as np
 import plotly.graph_objects as go
+from kaleidoscope.colors import DARK2
 from kaleidoscope.colors.utils import hex_to_rgb
 from kaleidoscope.interactive.plotly_wrapper import PlotlyFigure, PlotlyWidget
 from kaleidoscope.interactive.bloch.primitives import (BSPHERE, LATS, LONGS, ZAXIS, YAXIS, XAXIS,
                                                        Z0LABEL, Z1LABEL, YLABEL, XLABEL)
-
-# Default colors as dark2 from colorbrewer
-DEF_COLORS = ["#1b9e77", "#d95f02", "#7570b3", "#e7298a",
-              "#66a61e", "#e6ab02", "#a6761d", "#666666"]
 
 
 def bloch_sphere(vectors=None,
@@ -109,14 +106,14 @@ def bloch_sphere(vectors=None,
         if points_color is None:
             # passed a single point
             if nest_depth == 1:
-                points_color = [DEF_COLORS[0]]
+                points_color = [DARK2[0]]
             elif nest_depth == 2:
-                points_color = [[DEF_COLORS[kk % 8] for kk in range(len(points[0]))]]
+                points_color = [[DARK2[kk % 8] for kk in range(len(points[0]))]]
 
             elif nest_depth == 3:
                 points_color = []
                 for kk, pnts in enumerate(points):
-                    points_color.append(DEF_COLORS[kk % 8]*len(pnts))
+                    points_color.append(DARK2[kk % 8]*len(pnts))
 
         if nest_depth == 2 and nest_level(points_color) == 1:
             points_color = [points_color]
@@ -165,7 +162,7 @@ def bloch_sphere(vectors=None,
     if vectors is not None:
 
         if vectors_color is None:
-            vectors_color = [DEF_COLORS[kk+idx % 8] for kk in range(len(vectors))]
+            vectors_color = [DARK2[kk+idx % 8] for kk in range(len(vectors))]
 
         if isinstance(vectors_color, str):
             vectors_color = [vectors_color]

--- a/kaleidoscope/interactive/histogram.py
+++ b/kaleidoscope/interactive/histogram.py
@@ -33,6 +33,7 @@ import functools
 from collections import Counter, OrderedDict
 import numpy as np
 import plotly.graph_objects as go
+from kaleidoscope.colors import DARK2
 from .plotly_wrapper import PlotlyWidget, PlotlyFigure
 
 
@@ -56,7 +57,7 @@ VALID_SORTS = ['asc', 'desc', 'hamming']
 DIST_MEAS = {'hamming': hamming_distance}
 
 
-def counts_distribution(data, figsize=(None, None), color=None,
+def counts_distribution(data, figsize=(None, None), colors=None,
                         number_to_keep=None,
                         sort='asc', target_string=None,
                         legend=None, bar_labels=True,
@@ -68,7 +69,7 @@ def counts_distribution(data, figsize=(None, None), color=None,
         data (list or dict): This is either a list of dictionaries or a single
             dict containing the values to represent (ex {'001': 130})
         figsize (tuple): Figure size in pixels.
-        color (list or str): String or list of strings for histogram bar colors.
+        colors (list or str): String or list of strings for histogram bar colors.
         number_to_keep (int): The number of terms to plot and rest
             is made into a single bar called 'rest'.
         sort (string): Could be 'asc', 'desc', or 'hamming'.
@@ -90,6 +91,24 @@ def counts_distribution(data, figsize=(None, None), color=None,
         ValueError: When legend is provided and the length doesn't
                     match the input data.
         ImportError: When failed to load plotly.
+
+    Example:
+        .. jupyter-execute::
+
+            from kaleidoscope.qiskit.overload import QuantumCircuit
+            from kaleidoscope.qiskit.providers import simulators
+            from kaleidoscope.interactive import counts_distribution
+
+            sim = simulators.aer_vigo_simulator
+
+            qc = QuantumCircuit(3, 3) >> sim
+            qc.h(1)
+            qc.cx(1,0)
+            qc.cx(1,2)
+            qc.measure(range(3), range(3))
+
+            counts = qc.transpile().sample().result_when_done()
+            counts_distribution(counts, as_widget=True)
     """
 
     if sort not in VALID_SORTS:
@@ -129,10 +148,10 @@ def counts_distribution(data, figsize=(None, None), color=None,
                                                key=lambda pair: pair[0]))][1]
 
     # Set bar colors
-    if color is None:
-        color = ["#003f5c", "#ffa600", "#bc5090", "#58508d", "#ff6361"]
-    elif isinstance(color, str):
-        color = [color]
+    if colors is None:
+        colors = DARK2
+    elif isinstance(colors, str):
+        colors = [colors]
 
     width = 1/(len(data)+1)  # the width of the bars
 
@@ -158,7 +177,7 @@ def counts_distribution(data, figsize=(None, None), color=None,
                              width=width,
                              hoverinfo="text",
                              hovertext=hover_text,
-                             marker_color=color[item % len(color)],
+                             marker_color=colors[item % len(colors)],
                              name=legend[item] if legend else '',
                              text=np.round(yvals, 3) if bar_labels else None,
                              textposition='auto'

--- a/kaleidoscope/qiskit/backends/__init__.py
+++ b/kaleidoscope/qiskit/backends/__init__.py
@@ -25,9 +25,9 @@ System visualizations
 .. autosummary::
    :toctree: ../stubs/
 
-   plot_cnot_error_density
+   cnot_error_density
 
 """
 
-from .mpl.cnot_err import plot_cnot_error_density
+from .mpl.cnot_err import cnot_error_density
 from .interactive.error_map import system_error_map

--- a/kaleidoscope/qiskit/backends/__init__.py
+++ b/kaleidoscope/qiskit/backends/__init__.py
@@ -13,11 +13,11 @@
 # that they have been altered from the originals.
 
 """
-===========================================================
-IBM Quantum Backend Routines (:mod:`kaleidoscope.backends`)
-===========================================================
+==================================================================
+IBM Quantum Backend Routines (:mod:`kaleidoscope.qiskit.backends`)
+==================================================================
 
-.. currentmodule:: kaleidoscope.backends
+.. currentmodule:: kaleidoscope.qiskit.backends
 
 System visualizations
 =====================

--- a/kaleidoscope/qiskit/backends/mpl/__init__.py
+++ b/kaleidoscope/qiskit/backends/mpl/__init__.py
@@ -14,4 +14,4 @@
 
 """Matplotlib functions for backend plotting"""
 
-from .cnot_err import plot_cnot_error_density
+from .cnot_err import cnot_error_density

--- a/kaleidoscope/qiskit/backends/mpl/cnot_err.py
+++ b/kaleidoscope/qiskit/backends/mpl/cnot_err.py
@@ -19,15 +19,18 @@ from scipy.stats import gaussian_kde
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from kaleidoscope.colors import DARK2
+from kaleidoscope.errors import KaleidoscopeError
 
 
-def plot_cnot_error_density(backends, figsize=None, xlim=None,
-                            text_xval=None, xticks=None):
+def cnot_error_density(backends, figsize=None, 
+                       colors=None, xlim=None,
+                       text_xval=None, xticks=None):
     """Plot CNOT error distribution for one or more IBMQ backends.
 
     Parameters:
         backends (list or IBMQBackend): A single or list of IBMQBackend.
         figsize (tuple): Optional figure size in inches.
+        colors (list): A list of Matplotlib compatible colors to plot with.
         xlim (list or tuple): Optional lower and upper limits of cnot error values.
         text_xval (float): Optional xaxis value at which to start the backend text.
         xticks (list): Optional list of xaxis ticks to plot.
@@ -36,13 +39,14 @@ def plot_cnot_error_density(backends, figsize=None, xlim=None,
         Figure: A matplotlib Figure instance.
 
     Raises:
-        ValueError: A backend with <2 qubits was passed.
+        KaleidoscopeError: A backend with < 2 qubits was passed.
+        KaleidoscopeError: Number of colors did not match number of backends.
 
     Example:
         .. jupyter-execute::
 
             from qiskit import *
-            from kaleidoscope.backends import plot_cnot_error_density
+            from kaleidoscope.qiskit.backends import plot_cnot_error_density
             provider = IBMQ.load_account()
 
             backends = provider.backends(simulator=False,
@@ -56,7 +60,7 @@ def plot_cnot_error_density(backends, figsize=None, xlim=None,
 
     for back in backends:
         if back.configuration().n_qubits < 2:
-            raise ValueError('Number of backend qubits must be > 1')
+            raise KaleidoscopeError('Number of backend qubits must be > 1')
 
     # Attempt to autosize if figsize=None
     if figsize is None:
@@ -69,7 +73,11 @@ def plot_cnot_error_density(backends, figsize=None, xlim=None,
 
     text_color = 'k'
     offset = -100
-    colors = [DARK2[kk % 8] for kk in range(len(backends))]
+    if colors is None:
+        colors = [DARK2[kk % 8] for kk in range(len(backends))]
+    else:
+        if len(colors) != len(backends):
+            raise KaleidoscopeError('Number of colors does not match number of backends.')
 
     cx_errors = []
     for idx, back in enumerate(backends):

--- a/kaleidoscope/qiskit/backends/mpl/cnot_err.py
+++ b/kaleidoscope/qiskit/backends/mpl/cnot_err.py
@@ -22,7 +22,7 @@ from kaleidoscope.colors import DARK2
 from kaleidoscope.errors import KaleidoscopeError
 
 
-def cnot_error_density(backends, figsize=None, 
+def cnot_error_density(backends, figsize=None,
                        colors=None, xlim=None,
                        text_xval=None, xticks=None):
     """Plot CNOT error distribution for one or more IBMQ backends.

--- a/kaleidoscope/qiskit/backends/mpl/cnot_err.py
+++ b/kaleidoscope/qiskit/backends/mpl/cnot_err.py
@@ -15,13 +15,10 @@
 """CNOT error density plot"""
 
 import numpy as np
-import colorcet as cc
 from scipy.stats import gaussian_kde
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-
-
-CMAP = cc.cm.bmy
+from kaleidoscope.colors import DARK2
 
 
 def plot_cnot_error_density(backends, figsize=None, xlim=None,
@@ -72,8 +69,7 @@ def plot_cnot_error_density(backends, figsize=None, xlim=None,
 
     text_color = 'k'
     offset = -100
-    norm = plt.Normalize(0, len(backends))
-    colors = [CMAP(norm(kk)) for kk in range(len(backends))]
+    colors = [DARK2[kk % 8] for kk in range(len(backends))]
 
     cx_errors = []
     for idx, back in enumerate(backends):

--- a/kaleidoscope/qiskit/backends/mpl/cnot_err.py
+++ b/kaleidoscope/qiskit/backends/mpl/cnot_err.py
@@ -46,13 +46,13 @@ def cnot_error_density(backends, figsize=None,
         .. jupyter-execute::
 
             from qiskit import *
-            from kaleidoscope.qiskit.backends import plot_cnot_error_density
+            from kaleidoscope.qiskit.backends import cnot_error_density
             provider = IBMQ.load_account()
 
             backends = provider.backends(simulator=False,
                                          filters=lambda b: b.configuration().n_qubits == 5)
 
-            plot_cnot_error_density(backends)
+            cnot_error_density(backends)
     """
 
     if not isinstance(backends, list):


### PR DESCRIPTION
fixes #10 

Allow for passing colors into `cvnot_error_density`.  Also change default colors to dark2.